### PR TITLE
Make MuJoCo optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
                       'dm_control', # @ git+git://github.com/deepmind/dm_control@master#egg=dm_control
                       'mjrl', # @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl'
                       ],
+    extras_require={
+        "mujoco": ["mujoco_py"],
+    },
     packages=find_packages(),
     package_data={'d4rl': ['locomotion/assets/*',
                            'hand_manipulation_suite/assets/*',


### PR DESCRIPTION
Allowing to install D4RL without MuJoCo